### PR TITLE
Added Support for RocksDB backend

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -28,5 +28,6 @@
       "DEBUG",
       "NOTSET"
     ],
-    "include_schema_registry": "y"
+    "include_schema_registry": "y",
+    "include_rocksdb": "y"
 }

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -50,9 +50,7 @@ def context():
 @pytest.mark.parametrize(
     "include_schema_registry", YN_CHOICES, ids=lambda yn: f"schema_registry:{yn}"
 )
-@pytest.mark.parametrize(
-    "include_rocksdb", YN_CHOICES, ids=lambda yn: f"rocksdb:{yn}"
-)
+@pytest.mark.parametrize("include_rocksdb", YN_CHOICES, ids=lambda yn: f"rocksdb:{yn}")
 def context_combination(
     use_docker,
     include_docker_compose,
@@ -62,7 +60,7 @@ def context_combination(
     kafka_server_environment_variable,
     include_codec_example,
     include_schema_registry,
-    include_rocksdb
+    include_rocksdb,
 ):
     """Fixture that parametrize the function where it's used."""
     return {

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -50,6 +50,9 @@ def context():
 @pytest.mark.parametrize(
     "include_schema_registry", YN_CHOICES, ids=lambda yn: f"schema_registry:{yn}"
 )
+@pytest.mark.parametrize(
+    "include_rocksdb", YN_CHOICES, ids=lambda yn: f"rocksdb:{yn}"
+)
 def context_combination(
     use_docker,
     include_docker_compose,
@@ -70,6 +73,7 @@ def context_combination(
         "kafka_server_environment_variable": kafka_server_environment_variable,
         "include_codec_example": include_codec_example,
         "include_schema_registry": include_schema_registry,
+        "include_rocksdb": include_rocksdb,
     }
 
 

--- a/tests/test_cookiecutter_generation.py
+++ b/tests/test_cookiecutter_generation.py
@@ -62,6 +62,7 @@ def context_combination(
     kafka_server_environment_variable,
     include_codec_example,
     include_schema_registry,
+    include_rocksdb
 ):
     """Fixture that parametrize the function where it's used."""
     return {

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.7-slim
-    
+
 RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends apt-utils
@@ -11,6 +11,25 @@ RUN apt-get install -y netcat && apt-get autoremove -y
 
 # Create unprivileged user
 RUN adduser --disabled-password --gecos '' myuser
+
+{% if cookiecutter.include_rocksdb.lower() == "y" %}
+#Install RocksDB
+ENV DEBIAN_FRONTEND noninteractive
+ENV DEBIAN_FRONTEND teletype
+RUN apt-get upgrade -y gcc
+RUN apt-get install git make g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev -y
+
+RUN git clone https://github.com/facebook/rocksdb.git /tmp/rocksdb
+WORKDIR /tmp/rocksdb
+RUN make shared_lib INSTALL_PATH=/usr
+RUN make install-shared
+RUN rm -rf /tmp/rocksdb
+
+ENV CGO_CFLAGS  "-I/usr/local/include"
+ENV CGO_LDFLAGS "-L/usr/local/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"
+ENV LD_LIBRARY_PATH "/usr/local/lib"
+ENV STORE_URI=rocksdb://
+{% endif %}
 
 WORKDIR /{{cookiecutter.project_slug}}/
 

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -28,7 +28,6 @@ RUN rm -rf /tmp/rocksdb
 ENV CGO_CFLAGS  "-I/usr/local/include"
 ENV CGO_LDFLAGS "-L/usr/local/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"
 ENV LD_LIBRARY_PATH "/usr/local/lib"
-ENV STORE_URI=rocksdb://
 {% endif %}
 
 WORKDIR /{{cookiecutter.project_slug}}/

--- a/{{cookiecutter.project_slug}}/setup.py
+++ b/{{cookiecutter.project_slug}}/setup.py
@@ -3,8 +3,9 @@ from setuptools import setup, find_packages
 requires = [
     "avro-python3",
     "colorlog==3.1.4",
-    "fastavro",
-    "faust==1.7.0",
+    "fastavro",{% if cookiecutter.include_rocksdb.lower() == "y" %}
+    "faust[rocksdb]==1.7.0",{% else %}
+    "faust==1.7.0",{% endif %}
     "robinhood-aiokafka==1.0.3",
     "requests==2.22.0",
     "simple-settings==0.16.0",{% if cookiecutter.include_codec_example.lower() == "y" %}

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/app.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/app.py
@@ -1,3 +1,4 @@
+import os
 import faust
 
 from simple_settings import settings
@@ -9,7 +10,8 @@ app = faust.App(
     autodiscover=True,
     origin="{{cookiecutter.project_slug}}",
     id="1",
-    broker=settings.{{cookiecutter.kafka_server_environment_variable}}, 
+    broker=settings.{{cookiecutter.kafka_server_environment_variable}},
+    store=os.environ.get('STORE_URI', 'memory://'),
     logging_config=dictConfig(settings.LOGGING),
 )
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/app.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/app.py
@@ -11,7 +11,7 @@ app = faust.App(
     origin="{{cookiecutter.project_slug}}",
     id="1",
     broker=settings.{{cookiecutter.kafka_server_environment_variable}},
-    store=os.environ.get('STORE_URI', 'memory://'),
+    store=settings.STORE_URI,
     logging_config=dictConfig(settings.LOGGING),
 )
 

--- a/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
+++ b/{{cookiecutter.project_slug}}/{{cookiecutter.project_slug}}/settings.py
@@ -7,6 +7,11 @@ SIMPLE_SETTINGS = {
 # The following variables can be ovirriden from ENV
 {{cookiecutter.kafka_server_environment_variable}} = "kafka://kafka:9092"
 # SCHEMA_REGISTRY_URL = "http://schema-registry:8081"
+{% if cookiecutter.include_rocksdb.lower() == "y" %}
+STORE_URI = "rocksdb://"
+{% else %}
+STORE_URI = "memory://"
+{% endif %}
 
 LOGGING = {
     "version": 1,


### PR DESCRIPTION
This PR adds optional support for RocksDB backend. User needs to select this during project creation.

Summary of Changes:

- Added Rocksdb installation in `Dockerfile`.
- Install faust compatiable `python-rocksdb` lib.
- Added option in `cookiecutter.json`.
- Added parameter inside `test_project_generation`.