### PR TITLE
Feature/use rocksdb image from docker hub & Dockerfile improvements

### DIFF
--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,34 +1,22 @@
+{% if cookiecutter.include_rocksdb.lower() == "y" %}
+FROM marcosschroh/rocksdb:0.0.1
+
+{% else %}
 FROM python:3.7-slim
 
 RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
-    && apt-get update \
-    && apt-get install -y --no-install-recommends apt-utils
+    && apt-get update
+{% endif %}
+
+RUN apt-get install -y --no-install-recommends apt-utils \
+    && apt-get install -y netcat && apt-get autoremove -y \
+    && apt-get install gcc make g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev -y
 
 ENV PIP_FORMAT=legacy
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
 
-RUN apt-get install -y netcat && apt-get autoremove -y
-
 # Create unprivileged user
 RUN adduser --disabled-password --gecos '' myuser
-
-{% if cookiecutter.include_rocksdb.lower() == "y" %}
-#Install RocksDB
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBIAN_FRONTEND teletype
-RUN apt-get upgrade -y gcc
-RUN apt-get install git make g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev -y
-
-RUN git clone https://github.com/facebook/rocksdb.git /tmp/rocksdb
-WORKDIR /tmp/rocksdb
-RUN make shared_lib INSTALL_PATH=/usr
-RUN make install-shared
-RUN rm -rf /tmp/rocksdb
-
-ENV CGO_CFLAGS  "-I/usr/local/include"
-ENV CGO_LDFLAGS "-L/usr/local/lib -lrocksdb -lstdc++ -lm -lz -lbz2 -lsnappy"
-ENV LD_LIBRARY_PATH "/usr/local/lib"
-{% endif %}
 
 WORKDIR /{{cookiecutter.project_slug}}/
 

--- a/{{cookiecutter.project_slug}}/Dockerfile
+++ b/{{cookiecutter.project_slug}}/Dockerfile
@@ -1,16 +1,16 @@
 {% if cookiecutter.include_rocksdb.lower() == "y" %}
 FROM marcosschroh/rocksdb:0.0.1
 
+RUN apt-get install -y --no-install-recommends apt-utils \
+    && apt-get install -y netcat && apt-get autoremove -y \
+    && apt-get install gcc make g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev -y
+
 {% else %}
 FROM python:3.7-slim
 
 RUN echo 'deb [check-valid-until=no] http://archive.debian.org/debian jessie-backports main' >> /etc/apt/sources.list \
-    && apt-get update
+    && apt-get update && apt-get install -y netcat && apt-get autoremove -y
 {% endif %}
-
-RUN apt-get install -y --no-install-recommends apt-utils \
-    && apt-get install -y netcat && apt-get autoremove -y \
-    && apt-get install gcc make g++ libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev -y
 
 ENV PIP_FORMAT=legacy
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1
@@ -23,6 +23,10 @@ WORKDIR /{{cookiecutter.project_slug}}/
 COPY . /{{cookiecutter.project_slug}}
 
 RUN pip3 install -e .
+
+{% if cookiecutter.include_rocksdb.lower() == "y" %}
+RUN yes Y | apt-get remove --purge git libgflags-dev libsnappy-dev zlib1g-dev libbz2-dev liblz4-dev libzstd-dev
+{% endif %}
 
 ENTRYPOINT ["./run.sh"]
 


### PR DESCRIPTION
* When use `rocksdb` as storage, the base docker image is a pre-compiled docker image with `roocksdb` included. With this approach image size is decreased and we do not waste time compiling rockdb.
* Minor improvements in the `Dockerfile` reducing the amount of docker layer, so we can reduce the image size.

Results:

| Image size Master | Image size with improvement | Faust Storage |
|--------|------------ |-------|
| `1.31GB` | `583MB` | RocksDB |
| `200MB` | `198MB`| Memory |


The docker abse image when `rocksDB` is enabled is [this](https://github.com/marcosschroh/docker-rocksdb)
